### PR TITLE
Walk mode

### DIFF
--- a/config/dvrkTeleopParams.yaml
+++ b/config/dvrkTeleopParams.yaml
@@ -16,7 +16,8 @@ scaling: 0.1
 max_force: 10.0 # N
 
 # Leg control
-xy_twist_scale: 10.0 # cm/s per cm moved
+x_twist_scale: 10.0 # cm/s per cm moved
+y_twist_scale: 10.0 # cm/s per cm moved
 angular_twist_scale: 0.25 # rad/s per rad turned
 
 # Timeouts

--- a/config/dvrkTeleopParams.yaml
+++ b/config/dvrkTeleopParams.yaml
@@ -15,6 +15,10 @@ right_gripper_limits: [-3.1, 1.0]
 scaling: 0.1
 max_force: 10.0 # N
 
+# Leg control
+xy_twist_scale: 25.0 # cm/s per cm moved
+angular_twist_scale: 1.0 # rad/s per rad turned
+
 # Timeouts
 pose_expiration: 0.01 # s, if a dvrk pose is this stale we do not publish
 wrench_expiration: 0.1 # s, if a wrench is this stale we do not send

--- a/config/dvrkTeleopParams.yaml
+++ b/config/dvrkTeleopParams.yaml
@@ -16,8 +16,8 @@ scaling: 0.1
 max_force: 10.0 # N
 
 # Leg control
-xy_twist_scale: 25.0 # cm/s per cm moved
-angular_twist_scale: 1.0 # rad/s per rad turned
+xy_twist_scale: 10.0 # cm/s per cm moved
+angular_twist_scale: 0.25 # rad/s per rad turned
 
 # Timeouts
 pose_expiration: 0.01 # s, if a dvrk pose is this stale we do not publish

--- a/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
+++ b/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
@@ -58,7 +58,8 @@ protected:
   double maxForce_;
   std::vector<double> leftGripperLimits_;
   std::vector<double> rightGripperLimits_;
-  double xy_twist_scale_;
+  double x_twist_scale_;
+  double y_twist_scale_;
   double angular_twist_scale_;
 
   // Stuff we receive from DVRK

--- a/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
+++ b/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
@@ -77,7 +77,7 @@ protected:
   void dvrkGripperLeftCallback(const sensor_msgs::JointState::ConstPtr &msg);
   void dvrkGripperRightCallback(const sensor_msgs::JointState::ConstPtr &msg);
 
-  void dvrkMobileBaseStateCallback(const std_msgs::Empty::ConstPtr &msg);
+  void dvrkMobileBaseStateCallback(const std_msgs::Bool::ConstPtr &msg);
   void dvrkArmsStateCallback(const std_msgs::Empty::ConstPtr &msg);
   void dvrkControlStateCallback(const std_msgs::Empty::ConstPtr &msg);
 
@@ -111,7 +111,7 @@ protected:
   ros::Publisher leftGripperPub_;
   ros::Publisher rightGripperPub_;
   ros::Publisher twistDesPub_;
-  ros::Publisher dvrkControlStatePub_;
+  ros::Publisher dvrkControlModePub_;
 
   Eigen::Quaterniond rosQuatToEigen(const geometry_msgs::Quaternion &rosQuat);
 };

--- a/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
+++ b/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
@@ -101,6 +101,8 @@ protected:
   ros::Time lastLeftWrenchTime_;
   ros::Time lastRightWrenchTime_;
 
+  ros::Time otherDeviceTime_;
+
   // Stuff we (re-)publish
   ros::Publisher dvrkLeftWrenchPub_;
   ros::Publisher dvrkRightWrenchPub_;

--- a/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
+++ b/include/dvrk_teleop_interface/DVRKTeleopInterface.hpp
@@ -13,11 +13,11 @@
 #include <sensor_msgs/Joy.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
+#include <std_msgs/String.h>
 #include <tf2_ros/transform_broadcaster.h>
 
 namespace dvrk_teleop_interface {
 
-enum JoystickButtons { LeftClutch = 10, RightClutch = 11 };
 enum ControlStates { Arms = 0, Legs = 1};
 
 class DVRKTeleopInterface : public any_node::Node {
@@ -58,6 +58,8 @@ protected:
   double maxForce_;
   std::vector<double> leftGripperLimits_;
   std::vector<double> rightGripperLimits_;
+  double xy_twist_scale_;
+  double angular_twist_scale_;
 
   // Stuff we receive from DVRK
   ros::Subscriber dvrkPoseLeftSub_;
@@ -65,6 +67,8 @@ protected:
   ros::Subscriber dvrkClutchSub_;
   ros::Subscriber dvrkGripperLeftSub_;
   ros::Subscriber dvrkGripperRightSub_;
+  ros::Subscriber dvrkArmsStateSub_;
+  ros::Subscriber dvrkMobileBaseStateSub_;
   ros::Subscriber dvrkControlStateSub_;
 
   void dvrkPoseLeftCallback(const geometry_msgs::TransformStamped::ConstPtr &msg);
@@ -72,6 +76,9 @@ protected:
   void dvrkClutchCallback(const std_msgs::Bool::ConstPtr &msg);
   void dvrkGripperLeftCallback(const sensor_msgs::JointState::ConstPtr &msg);
   void dvrkGripperRightCallback(const sensor_msgs::JointState::ConstPtr &msg);
+
+  void dvrkMobileBaseStateCallback(const std_msgs::Empty::ConstPtr &msg);
+  void dvrkArmsStateCallback(const std_msgs::Empty::ConstPtr &msg);
   void dvrkControlStateCallback(const std_msgs::Empty::ConstPtr &msg);
 
   sensor_msgs::JointState processGripperLimits(const sensor_msgs::JointState& gripperState, std::vector<double> gripperLimits);
@@ -104,6 +111,7 @@ protected:
   ros::Publisher leftGripperPub_;
   ros::Publisher rightGripperPub_;
   ros::Publisher twistDesPub_;
+  ros::Publisher dvrkControlStatePub_;
 
   Eigen::Quaterniond rosQuatToEigen(const geometry_msgs::Quaternion &rosQuat);
 };

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <exec_depend>dvrk_control</exec_depend>
   
   <test_depend>cmake_code_coverage</test_depend>
   <test_depend>gtest</test_depend>

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -41,11 +41,11 @@ bool DVRKTeleopInterface::init() {
   teleopRightWrenchSub_ = nh_->subscribe(
       teleopRightWrenchTopic_, 1, &DVRKTeleopInterface::teleopRightWrenchCallback, this);
   dvrkArmsStateSub_ = nh_->subscribe(
-      "/mobile_manipulator_state_machine/arms_state", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
+      "/mobile_manipulator_state_machine/manipulator_control", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
   dvrkMobileBaseStateSub_ = nh_->subscribe
-      ("/mobile_manipulator_state_machine/mobile_base_state", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
+      ("/mobile_manipulator_state_machine/mobile_base_control", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
   dvrkControlStateSub_ = nh_->subscribe(
-      "/mobile_manipulator_state_machine/control_state", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
+      "/mobile_manipulator_state_machine/switch_control_mode", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
 
   // Initialize publishers
   dvrkLeftWrenchPub_ =
@@ -99,7 +99,7 @@ bool DVRKTeleopInterface::update(const any_worker::WorkerEvent &event) {
   }
 
   std_msgs::Bool teleopClutch;
-  teleopClutch.data= dvrkClutch_.data;
+  teleopClutch.data = dvrkClutch_.data;
   leftTeleopClutchPub_.publish(teleopClutch);
   rightTeleopClutchPub_.publish(teleopClutch);
 
@@ -146,10 +146,8 @@ void DVRKTeleopInterface::processTeleopWrench(const geometry_msgs::WrenchStamped
   Eigen::Vector3d force;
   force << dvrkWrench.wrench.force.x, dvrkWrench.wrench.force.y,
       dvrkWrench.wrench.force.z;
-  Eigen::Quaterniond quat = rosQuatToEigen(dvrk_pose.transform.rotation);
-  Eigen::Matrix3d frameCorrection = quat.inverse().toRotationMatrix();
 
-  force = forceScaling_ * frameCorrection * normalCoordToDvrkCoord_ * force;
+  force = forceScaling_ * force;
 
   if (force.norm() > maxForce_) {
     force = maxForce_ * force / force.norm();

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -192,15 +192,16 @@ void DVRKTeleopInterface::processDVRKPoseForLegs(const geometry_msgs::TransformS
     Eigen::Quaterniond quatInit = rosQuatToEigen(twistDesInitPose_.transform.rotation);
     Eigen::Quaterniond quat = rosQuatToEigen(dvrk_pose.transform.rotation);
     Eigen::Quaterniond quatDiff = quatInit.inverse() * quat;
-    Eigen::Vector3d euler = quatDiff.toRotationMatrix().eulerAngles(0, 1, 2);
-    double rotationCmd = euler[2];
+    Eigen::Matrix3d rotDiff = quatDiff.toRotationMatrix();
+    double angle = atan2(rotDiff(1, 0), rotDiff(0, 0));
+
     geometry_msgs::TwistStamped twistDes;
     twistDes.twist.linear.x = xy_twist_scale_ * posErr[0];
     twistDes.twist.linear.y = xy_twist_scale_ * posErr[1];
     twistDes.twist.linear.z = 0.0;
     twistDes.twist.angular.x = 0.0;
     twistDes.twist.angular.y = 0.0;
-    twistDes.twist.angular.z = rotationCmd * angular_twist_scale_;
+    twistDes.twist.angular.z = angle * angular_twist_scale_;
     pub.publish(twistDes);
   } else {
     geometry_msgs::TwistStamped twistDes;

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -201,16 +201,10 @@ void DVRKTeleopInterface::processDVRKPoseForLegs(const geometry_msgs::TransformS
     twistDes.twist.linear.z = 0.0;
     twistDes.twist.angular.x = 0.0;
     twistDes.twist.angular.y = 0.0;
-    twistDes.twist.angular.z = angle * angular_twist_scale_;
+    twistDes.twist.angular.z = -angle * angular_twist_scale_;
     pub.publish(twistDes);
   } else {
     geometry_msgs::TwistStamped twistDes;
-    twistDes.twist.linear.x = 0.0;
-    twistDes.twist.linear.y = 0.0;
-    twistDes.twist.linear.z = 0.0;
-    twistDes.twist.angular.x = 0.0;
-    twistDes.twist.angular.y = 0.0;
-    twistDes.twist.angular.z = 0.0;
     pub.publish(twistDes);
   }
 }

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -60,7 +60,7 @@ bool DVRKTeleopInterface::init() {
       "/teleop/right/leader_pose", 1);
   leftGripperPub_ = nh_->advertise<sensor_msgs::JointState>(teleopLeftGripperTopic_, 1);
   rightGripperPub_ = nh_->advertise<sensor_msgs::JointState>(teleopRightGripperTopic_, 1);
-  twistDesPub_ = nh_->advertise<geometry_msgs::TwistStamped>("/teleop/base/twist_des", 1);
+  twistDesPub_ = nh_->advertise<geometry_msgs::TwistStamped>("/teleop/base/twist", 1);
   dvrkControlModePub_ = nh_->advertise<std_msgs::String>("/dvrk_control/control_mode", 1);
 
   // start in arms mode

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -61,13 +61,13 @@ bool DVRKTeleopInterface::init() {
   leftGripperPub_ = nh_->advertise<sensor_msgs::JointState>(teleopLeftGripperTopic_, 1);
   rightGripperPub_ = nh_->advertise<sensor_msgs::JointState>(teleopRightGripperTopic_, 1);
   twistDesPub_ = nh_->advertise<geometry_msgs::TwistStamped>("/teleop/base/twist_des", 1);
-  dvrkControlStatePub_ = nh_->advertise<std_msgs::String>("/dvrk_control/control_state", 1);
+  dvrkControlModePub_ = nh_->advertise<std_msgs::String>("/dvrk_control/control_mode", 1);
 
   // start in arms mode
   controlState_ = ControlStates::Arms;
   std_msgs::String state;
   state.data = "wrench";
-  dvrkControlStatePub_.publish(state);
+  dvrkControlModePub_.publish(state);
 
 
   // Initialize coord transform
@@ -243,15 +243,15 @@ void DVRKTeleopInterface::dvrkArmsStateCallback(const std_msgs::Empty::ConstPtr 
   controlState_ = ControlStates::Arms;
   std_msgs::String state;
   state.data = "wrench";
-  dvrkControlStatePub_.publish(state);
+  dvrkControlModePub_.publish(state);
   ROS_INFO_STREAM("Control state changed to Arms");
 }
 
-void DVRKTeleopInterface::dvrkMobileBaseStateCallback(const std_msgs::Empty::ConstPtr &msg) {
+void DVRKTeleopInterface::dvrkMobileBaseStateCallback(const std_msgs::Bool::ConstPtr &msg) {
   controlState_ = ControlStates::Legs;
   std_msgs::String state;
   state.data = "pose";
-  dvrkControlStatePub_.publish(state);
+  dvrkControlModePub_.publish(state);
   ROS_INFO_STREAM("Control state changed to Legs");
 }
 

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -193,13 +193,19 @@ void DVRKTeleopInterface::processDVRKPoseForLegs(const geometry_msgs::TransformS
     Eigen::Quaterniond quat = rosQuatToEigen(dvrk_pose.transform.rotation);
     Eigen::Quaterniond quatDiff = quatInit.inverse() * quat;
     Eigen::Vector3d euler = quatDiff.toRotationMatrix().eulerAngles(0, 1, 2);
+    double rotationCmd = euler[2];
+    if (rotationCmd > M_PI) {
+      rotationCmd -= M_PI;
+    } else if (rotationCmd < -M_PI) {
+      rotationCmd += M_PI;
+    }
     geometry_msgs::TwistStamped twistDes;
     twistDes.twist.linear.x = xy_twist_scale_ * posErr[0];
     twistDes.twist.linear.y = xy_twist_scale_ * posErr[1];
     twistDes.twist.linear.z = 0.0;
     twistDes.twist.angular.x = 0.0;
     twistDes.twist.angular.y = 0.0;
-    twistDes.twist.angular.z = euler[2];
+    twistDes.twist.angular.z = rotationCmd * angular_twist_scale_;
     pub.publish(twistDes);
   } else {
     geometry_msgs::TwistStamped twistDes;

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -41,9 +41,9 @@ bool DVRKTeleopInterface::init() {
   teleopRightWrenchSub_ = nh_->subscribe(
       teleopRightWrenchTopic_, 1, &DVRKTeleopInterface::teleopRightWrenchCallback, this);
   dvrkArmsStateSub_ = nh_->subscribe(
-      "/mobile_manipulator_state_machine/manipulator_control", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
+      "/mobile_manipulator_state_machine/manipulator_control", 1, &DVRKTeleopInterface::dvrkArmsStateCallback, this);
   dvrkMobileBaseStateSub_ = nh_->subscribe
-      ("/mobile_manipulator_state_machine/mobile_base_control", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
+      ("/mobile_manipulator_state_machine/mobile_base_control", 1, &DVRKTeleopInterface::dvrkMobileBaseStateCallback, this);
   dvrkControlStateSub_ = nh_->subscribe(
       "/mobile_manipulator_state_machine/switch_control_mode", 1, &DVRKTeleopInterface::dvrkControlStateCallback, this);
 
@@ -62,6 +62,12 @@ bool DVRKTeleopInterface::init() {
   rightGripperPub_ = nh_->advertise<sensor_msgs::JointState>(teleopRightGripperTopic_, 1);
   twistDesPub_ = nh_->advertise<geometry_msgs::TwistStamped>("/teleop/base/twist_des", 1);
   dvrkControlStatePub_ = nh_->advertise<std_msgs::String>("/dvrk_control/control_state", 1);
+
+  // start in arms mode
+  controlState_ = ControlStates::Arms;
+  std_msgs::String state;
+  state.data = "wrench";
+  dvrkControlStatePub_.publish(state);
 
 
   // Initialize coord transform
@@ -236,7 +242,7 @@ void DVRKTeleopInterface::dvrkGripperRightCallback(const sensor_msgs::JointState
 void DVRKTeleopInterface::dvrkArmsStateCallback(const std_msgs::Empty::ConstPtr &msg) {
   controlState_ = ControlStates::Arms;
   std_msgs::String state;
-  state.data = "pose";
+  state.data = "wrench";
   dvrkControlStatePub_.publish(state);
   ROS_INFO_STREAM("Control state changed to Arms");
 }
@@ -244,8 +250,7 @@ void DVRKTeleopInterface::dvrkArmsStateCallback(const std_msgs::Empty::ConstPtr 
 void DVRKTeleopInterface::dvrkMobileBaseStateCallback(const std_msgs::Empty::ConstPtr &msg) {
   controlState_ = ControlStates::Legs;
   std_msgs::String state;
-  state.data = "wrench";
-  dvrkControlStatePub_.publish(state);
+  state.data = "pose";
   dvrkControlStatePub_.publish(state);
   ROS_INFO_STREAM("Control state changed to Legs");
 }

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -194,11 +194,6 @@ void DVRKTeleopInterface::processDVRKPoseForLegs(const geometry_msgs::TransformS
     Eigen::Quaterniond quatDiff = quatInit.inverse() * quat;
     Eigen::Vector3d euler = quatDiff.toRotationMatrix().eulerAngles(0, 1, 2);
     double rotationCmd = euler[2];
-    if (rotationCmd > M_PI) {
-      rotationCmd -= M_PI;
-    } else if (rotationCmd < -M_PI) {
-      rotationCmd += M_PI;
-    }
     geometry_msgs::TwistStamped twistDes;
     twistDes.twist.linear.x = xy_twist_scale_ * posErr[0];
     twistDes.twist.linear.y = xy_twist_scale_ * posErr[1];

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -23,7 +23,8 @@ bool DVRKTeleopInterface::init() {
   rightGripperLimits_ = param<std::vector<double>>("right_gripper_limits", {0., 1.0});
   forceScaling_ = param<double>("force_scaling", 0.2);
   maxForce_ = param<double>("max_force", 20.0);
-  xy_twist_scale_ = param<double>("xy_twist_scale", 25.0);
+  x_twist_scale_ = param<double>("x_twist_scale", 25.0);
+  y_twist_scale_ = param<double>("y_twist_scale", 25.0);
   angular_twist_scale_ = param<double>("angular_twist_scale", 25.0);
   // Initialize subscribers
   dvrkPoseLeftSub_ = nh_->subscribe(
@@ -199,8 +200,8 @@ void DVRKTeleopInterface::processDVRKPoseForLegs(const geometry_msgs::TransformS
 
     geometry_msgs::TwistStamped twistDes;
     twistDes.header.stamp = otherDeviceTime_;
-    twistDes.twist.linear.x = xy_twist_scale_ * posErr[0];
-    twistDes.twist.linear.y = xy_twist_scale_ * posErr[1];
+    twistDes.twist.linear.x = x_twist_scale_ * posErr[0];
+    twistDes.twist.linear.y = y_twist_scale_ * posErr[1];
     twistDes.twist.linear.z = 0.0;
     twistDes.twist.angular.x = 0.0;
     twistDes.twist.angular.y = 0.0;

--- a/src/DVRKTeleopInterface.cpp
+++ b/src/DVRKTeleopInterface.cpp
@@ -179,14 +179,23 @@ void DVRKTeleopInterface::processDVRKPoseForLegs(const geometry_msgs::TransformS
   }
 
   if (twistDesInitialized_){
-    geometry_msgs::TransformStamped teleopPose = dvrk_pose;
+    Eigen::Vector3d posInit;
+    posInit << twistDesInitPose_.transform.translation.x,
+        twistDesInitPose_.transform.translation.y,
+        twistDesInitPose_.transform.translation.z;
+    Eigen::Vector3d posNow;
+    posNow << dvrk_pose.transform.translation.x,
+        dvrk_pose.transform.translation.y,
+        dvrk_pose.transform.translation.z;
+    Eigen::Vector3d posErr =  dvrkCoordToNormalCoord_ * (posNow - posInit);
+
     Eigen::Quaterniond quatInit = rosQuatToEigen(twistDesInitPose_.transform.rotation);
     Eigen::Quaterniond quat = rosQuatToEigen(dvrk_pose.transform.rotation);
     Eigen::Quaterniond quatDiff = quatInit.inverse() * quat;
     Eigen::Vector3d euler = quatDiff.toRotationMatrix().eulerAngles(0, 1, 2);
     geometry_msgs::TwistStamped twistDes;
-    twistDes.twist.linear.x = euler[1];
-    twistDes.twist.linear.y = euler[0];
+    twistDes.twist.linear.x = xy_twist_scale_ * posErr[0];
+    twistDes.twist.linear.y = xy_twist_scale_ * posErr[1];
     twistDes.twist.linear.z = 0.0;
     twistDes.twist.angular.x = 0.0;
     twistDes.twist.angular.y = 0.0;


### PR DESCRIPTION
Allows for switching into "walk mode" with middle pedal.

In walk mode, the arms will pop up into a resting position. The user can then clutch in and push the arm around to generate an intuitive twist command. The clutch is hold, not toggle.

The user can switch back to the normal manipulation mode with the middle pedal.